### PR TITLE
Allow req.session.user.role to be an array of roles

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,10 +132,17 @@ Acl.prototype.middleware = function(){
         req.role = new Role( acl.roles );
         res.locals.role = req.role;
         if ( req.session && req.session.user ){
-            if ( req.session.user.role )
-                req.role.addRole( req.session.user.role );
-            else
+            if ( req.session.user.role ){
+                if ( req.session.user.role instanceof Array ) {
+                    req.session.user.role.forEach( function(role) {
+                        req.role.addRole( role );
+                    });
+                } else {
+                    req.role.addRole( req.session.user.role );
+                }
+            } else {
                 req.role.setAuthorized( true );
+            }
         }
         next();
     }


### PR DESCRIPTION
Hi,

It would be nice to have either an array of roles or a single string in the req.session.user.role property, so you can handle multiples roles for a given user directly in the middleware.

The change is pretty straightforward and obviously backward compatible.

Thanks for your review.
/Jim
