### PR TITLE
Allow user to supply where the session object lives

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ role.onUnauthorizedFailure( function( req, res ){
     res.redirect( '/' );
 });
 
+// Define where the user session is on the request object
+role.userSessionHandler( function( req ) {
+    // Example using custom Passport auth
+    return req.user;
+});
+
 // Сonnect a middleware
 app.use( role.middleware() );
 

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ Acl.prototype.is = function( roleName, failureBack ){
         if ( req.role && req.role.is(roleName) )
             next();
         else
-            acl.handleFailure( req, res, next, failureBack )
+            acl.handleFailure( req, res, next, failureBack );
     };
 };
 
@@ -56,7 +56,7 @@ Acl.prototype.isAny = function( roles, failureBack ){
         if ( req.role && req.role.isAny(roles) )
             next();
         else
-            acl.handleFailure( req, res, next, failureBack )
+            acl.handleFailure( req, res, next, failureBack );
     };
 };
 
@@ -105,7 +105,7 @@ Acl.prototype.can = function( permissionName, failureBack ){
         if ( req.role && req.role.can(permissionName) )
             next();
         else
-            acl.handleFailure( req, res, next, failureBack )
+            acl.handleFailure( req, res, next, failureBack );
     };
 };
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Acl( rolesConfig ){
     this.roles = rolesConfig;
     this.authorizedFailureHandler = null;
     this.unauthorizedFailureHandler = null;
+    this.userSessionHandler = null;
 }
 
 
@@ -125,20 +126,34 @@ Acl.prototype.onUnauthorizedFailure = function( fn ){
     this.unauthorizedFailureHandler = fn;
 };
 
+/**
+ * @param {Function} fn
+ */
+Acl.prototype.userSessionHandler = function( fn ){
+    this.userSessionHandler = fn;
+};
 
 Acl.prototype.middleware = function(){
     var acl = this;
     return function( req, res, next ){
         req.role = new Role( acl.roles );
         res.locals.role = req.role;
-        if ( req.session && req.session.user ){
-            if ( req.session.user.role )
-                req.role.addRole( req.session.user.role );
-            else
-                req.role.setAuthorized( true );
+
+        var user = req.session && req.session.user;
+
+        // Allow custom lookup of user
+        if (typeof acl.userSessionHandler === 'function') {
+          user = acl.userSessionHandler(req);
         }
+
+        if ( user.role ) {
+          req.role.addRole( user.role );
+        } else {
+          req.role.setAuthorized( true );
+        }
+
         next();
-    }
+    };
 };
 
 


### PR DESCRIPTION
The genesis of this is that my application uses http://passportjs.org for authentication, meaning my user's session does not live at `req.session.user`.

Rather than make a specific fallback for Passport, I introduced a handler which allows the developer to supply where on the request object the user data lives (in Passport's case, `req.user`).
